### PR TITLE
Feat/locales

### DIFF
--- a/src/event_calplot/locales.py
+++ b/src/event_calplot/locales.py
@@ -1,3 +1,5 @@
+"""Locale support for date labels in different languages."""
+
 from typing import TypedDict
 
 

--- a/src/event_calplot/locales.py
+++ b/src/event_calplot/locales.py
@@ -1,0 +1,62 @@
+from typing import TypedDict
+
+
+class DateLabels(TypedDict):
+    """A TypedDict for date labels in different languages."""
+
+    months: list[str]
+    weekdays: list[str]
+
+
+def get_locale_text(language: str = "en") -> DateLabels:
+    """Get date labels for a specific language.
+
+    Parameters
+    ----------
+    language : str, optional
+        The language code for the desired locale, by default "en"
+
+    Returns
+    -------
+    DateLabels
+        The date labels for the specified language
+    """
+
+    locales = {
+        "en": DateLabels(
+            months=[
+                "Jan",
+                "Feb",
+                "Mar",
+                "Apr",
+                "May",
+                "Jun",
+                "Jul",
+                "Aug",
+                "Sep",
+                "Oct",
+                "Nov",
+                "Dec",
+            ],
+            weekdays=["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        ),
+        "ko": DateLabels(
+            months=[
+                "1월",
+                "2월",
+                "3월",
+                "4월",
+                "5월",
+                "6월",
+                "7월",
+                "8월",
+                "9월",
+                "10월",
+                "11월",
+                "12월",
+            ],
+            weekdays=["월", "화", "수", "목", "금", "토", "일"],
+        ),
+        # Add more languages as needed
+    }
+    return locales.get(language, locales["en"])


### PR DESCRIPTION
This pull request introduces locale support for date labels in different languages to the `src/event_calplot/locales.py` module. The main addition is a function that provides localized month and weekday names based on a specified language code.

## Locale support for date labels:

* Added a new module `src/event_calplot/locales.py` containing the `DateLabels` TypedDict and the `get_locale_text` function, which returns localized month and weekday labels for supported languages (currently English and Korean).